### PR TITLE
Fix compatibility between most recent official PubSub version and the one used by live-service

### DIFF
--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -62,7 +62,7 @@ defmodule Phoenix.PubSub.PG2 do
     name = Keyword.fetch!(opts, :name)
     pool_size = Keyword.get(opts, :pool_size, 1)
     adapter_name = Keyword.fetch!(opts, :adapter_name)
-    Supervisor.start_link(__MODULE__, {name, adapter_name, pool_size}, name: :"#{adapter_name}_supervisor")
+    Supervisor.start_link(__MODULE__, {name, adapter_name, pool_size}, name: adapter_name)
   end
 
   @impl true
@@ -71,10 +71,6 @@ defmodule Phoenix.PubSub.PG2 do
       for number <- 1..pool_size do
         :"#{adapter_name}_#{number}"
       end
-
-    # Add an `adapter_name` group for the first in the pool for backwards compatability
-    # with v2.0 when the pool_size is 1.
-    groups = [adapter_name | groups]
 
     :persistent_term.put(adapter_name, List.to_tuple(groups))
 

--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -67,12 +67,12 @@ defmodule Phoenix.PubSub.PG2 do
 
   @impl true
   def init({name, adapter_name, pool_size}) do
-    [_ | groups] =
+    groups =
       for number <- 1..pool_size do
         :"#{adapter_name}_#{number}"
       end
 
-    # Use `adapter_name` for the first in the pool for backwards compatability
+    # Add an `adapter_name` group for the first in the pool for backwards compatability
     # with v2.0 when the pool_size is 1.
     groups = [adapter_name | groups]
 


### PR DESCRIPTION
## Context

Because our PubSub fork diverged from an unreleased PubSub version, a thing we relied on was considered to be a bug by a Phoenix team (rightfully so). When the bug was fixed, the broke the compatibility between the old version and the new version (the one with the bug fixed).

1. Before https://github.com/Whatnot-Inc/whatnot_live/commit/da1ae51ca6a8d8eee3d93bf1e149a32087ef7da7, we were using this version of PubSub:

https://github.com/Whatnot-Inc/phoenix_pubsub/blob/9de02c35923b71450f06aa175aa40d578a70f3aa/lib/phoenix/pubsub/pg2.ex#L70-L72

The `:pg` group name we used was: `Elixir.Phoenix.PubSub.PG2_1`.

2. After https://github.com/Whatnot-Inc/whatnot_live/commit/da1ae51ca6a8d8eee3d93bf1e149a32087ef7da7, the version of PubSub was updated, and the `:pg` group name we use changed to `Elixir.Phoenix.PubSub.PG2`:

https://github.com/Whatnot-Inc/phoenix_pubsub/blob/a626eec28c0e7bbbd8aefc73a9247e996f5597cf/lib/phoenix/pubsub/pg2.ex#L70-L77

Since `:pg` group names are not the same, the messages wouldn't be broadcasted between the nodes running the old and the new version.

## Changes

This reverts the commit that fixes the "bug", so that `:pg` group names are compatible again.

## Tests

Tested via deployment tests from this PR: https://github.com/Whatnot-Inc/whatnot_live/pull/1180.

## Other considerations

If we'd like to switch to upstream Phoenix.PubSub again, we'll need to do some juggling to make sure the PG group names are compatible across the versions.