### PR TITLE
Ignore the pool size on the sending side

### DIFF
--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -72,7 +72,8 @@ defmodule Phoenix.PubSub.PG2 do
         :"#{adapter_name}_#{number}"
       end
 
-    :persistent_term.put(adapter_name, List.to_tuple(groups))
+    [first_group | _] = groups
+    :persistent_term.put(adapter_name, List.to_tuple([first_group]))
 
     children =
       for group <- groups do


### PR DESCRIPTION
This makes the node send all communication through the first PG member, but receive it on all `pool_size` members. This allows two nodes with pool sizes of `1` and `n` to communicate.