### PR TITLE
Add `dirty_get_by_key`

### DIFF
--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -207,6 +207,13 @@ defmodule Phoenix.Tracker do
   def list(tracker_name, topic) do
     tracker_name
     |> Shard.name_for_topic(topic, pool_size(tracker_name))
+    |> Phoenix.Tracker.Shard.list(topic)
+  end
+
+  @spec dirty_list(atom, topic) :: [presence]
+  def dirty_list(tracker_name, topic) do
+    tracker_name
+    |> Shard.name_for_topic(topic, pool_size(tracker_name))
     |> Phoenix.Tracker.Shard.dirty_list(topic)
   end
 

--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -231,6 +231,13 @@ defmodule Phoenix.Tracker do
     |> Phoenix.Tracker.Shard.get_by_key(topic, key)
   end
 
+  @spec dirty_get_by_key(atom, topic, term) :: [presence]
+  def dirty_get_by_key(tracker_name, topic, key) do
+    tracker_name
+    |> Shard.name_for_topic(topic, pool_size(tracker_name))
+    |> Phoenix.Tracker.Shard.dirty_get_by_key(topic, key)
+  end
+
   @doc """
   Gracefully shuts down by broadcasting permdown to all replicas.
 

--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -238,13 +238,6 @@ defmodule Phoenix.Tracker do
     |> Phoenix.Tracker.Shard.get_by_key(topic, key)
   end
 
-  @spec dirty_get_by_key(atom, topic, term) :: [presence]
-  def dirty_get_by_key(tracker_name, topic, key) do
-    tracker_name
-    |> Shard.name_for_topic(topic, pool_size(tracker_name))
-    |> Phoenix.Tracker.Shard.dirty_get_by_key(topic, key)
-  end
-
   @doc """
   Gracefully shuts down by broadcasting permdown to all replicas.
 

--- a/lib/phoenix/tracker/shard.ex
+++ b/lib/phoenix/tracker/shard.ex
@@ -4,36 +4,37 @@ defmodule Phoenix.Tracker.Shard do
   alias Phoenix.Tracker.{Clock, State, Replica, DeltaGeneration}
   require Logger
 
-  @type presence :: {key :: String.t, meta :: map()}
-  @type topic :: String.t
+  @type presence :: {key :: String.t(), meta :: map()}
+  @type topic :: String.t()
 
-  @callback init(Keyword.t) :: {:ok, pid} | {:error, reason :: term}
-  @callback handle_diff(%{topic => {joins :: [presence], leaves :: [presence]}}, state :: term) :: {:ok, state :: term}
+  @callback init(Keyword.t()) :: {:ok, pid} | {:error, reason :: term}
+  @callback handle_diff(%{topic => {joins :: [presence], leaves :: [presence]}}, state :: term) ::
+              {:ok, state :: term}
   @callback handle_info(message :: term, state :: term) :: {:noreply, state :: term}
   @optional_callbacks handle_info: 2
 
   @type t :: %{
-    shard_name: String.t(),
-    pubsub_server: atom(),
-    tracker: module,
-    tracker_state: any,
-    replica: Replica.t(),
-    report_events_to: any,
-    namespaced_topic: String.t(),
-    log_level: boolean | atom,
-    replicas: map,
-    pending_clockset: [],
-    presences: State.t(),
-    broadcast_period: integer,
-    max_silent_periods: integer(),
-    silent_periods: integer(),
-    down_period: integer,
-    permdown_period: integer,
-    clock_sample_periods: integer,
-    deltas: [State.delta()],
-    max_delta_sizes: integer,
-    current_sample_count: integer
-  }
+          shard_name: String.t(),
+          pubsub_server: atom(),
+          tracker: module,
+          tracker_state: any,
+          replica: Replica.t(),
+          report_events_to: any,
+          namespaced_topic: String.t(),
+          log_level: boolean | atom,
+          replicas: map,
+          pending_clockset: [],
+          presences: State.t(),
+          broadcast_period: integer,
+          max_silent_periods: integer(),
+          silent_periods: integer(),
+          down_period: integer,
+          permdown_period: integer,
+          clock_sample_periods: integer,
+          deltas: [State.delta()],
+          max_delta_sizes: integer,
+          current_sample_count: integer
+        }
 
   ## Used by Phoenix.Tracker for dispatching to appropriate shard
   @spec name_for_number(atom, non_neg_integer) :: atom
@@ -58,12 +59,15 @@ defmodule Phoenix.Tracker.Shard do
   def untrack(server_pid, pid, topic, key) when is_pid(pid) do
     GenServer.call(server_pid, {:untrack, pid, topic, key})
   end
+
   def untrack(server_pid, pid) when is_pid(pid) do
     GenServer.call(server_pid, {:untrack, pid})
   end
 
-  @spec update(pid, pid, topic, term, map() | (map() -> map())) :: {:ok, ref :: binary} | {:error, reason :: term}
-  def update(server_pid, pid, topic, key, meta) when is_pid(pid) and (is_map(meta) or is_function(meta)) do
+  @spec update(pid, pid, topic, term, map() | (map() -> map())) ::
+          {:ok, ref :: binary} | {:error, reason :: term}
+  def update(server_pid, pid, topic, key, meta)
+      when is_pid(pid) and (is_map(meta) or is_function(meta)) do
     GenServer.call(server_pid, {:update, pid, topic, key, meta})
   end
 
@@ -86,6 +90,11 @@ defmodule Phoenix.Tracker.Shard do
     |> State.get_by_key(topic, key)
   end
 
+  @spec dirty_get_by_key(atom, topic, term) :: [presence]
+  def dirty_get_by_key(shard_name, topic, key) do
+    State.tracked_key(shard_name, topic, key, [])
+  end
+
   @spec graceful_permdown(pid) :: :ok
   def graceful_permdown(server_pid) do
     GenServer.call(server_pid, :graceful_permdown)
@@ -98,98 +107,112 @@ defmodule Phoenix.Tracker.Shard do
     tracker_name = Keyword.fetch!(pool_opts, :name)
     name = name_for_number(tracker_name, number)
     shard_opts = Keyword.put(pool_opts, :name, name)
-    GenServer.start_link(__MODULE__,
-      [tracker, tracker_opts, shard_opts], name: name)
+
+    GenServer.start_link(
+      __MODULE__,
+      [tracker, tracker_opts, shard_opts],
+      name: name
+    )
   end
 
   def init([tracker, tracker_opts, shard_opts]) do
     Process.flag(:trap_exit, true)
-    shard_name           = Keyword.fetch!(shard_opts, :name)
-    pubsub_server        = Keyword.fetch!(shard_opts, :pubsub_server)
-    broadcast_period     = shard_opts[:broadcast_period] || 1500
-    max_silent_periods   = shard_opts[:max_silent_periods] || 10
-    down_period          = shard_opts[:down_period]
-                         || (broadcast_period * max_silent_periods * 2)
-    permdown_period      = shard_opts[:permdown_period] || 1_200_000
+    shard_name = Keyword.fetch!(shard_opts, :name)
+    pubsub_server = Keyword.fetch!(shard_opts, :pubsub_server)
+    broadcast_period = shard_opts[:broadcast_period] || 1500
+    max_silent_periods = shard_opts[:max_silent_periods] || 10
+
+    down_period =
+      shard_opts[:down_period] ||
+        broadcast_period * max_silent_periods * 2
+
+    permdown_period = shard_opts[:permdown_period] || 1_200_000
     clock_sample_periods = shard_opts[:clock_sample_periods] || 2
-    log_level            = Keyword.get(shard_opts, :log_level, false)
-    max_delta_sizes      = shard_opts[:max_delta_sizes] || [100, 1000, 10_000]
+    log_level = Keyword.get(shard_opts, :log_level, false)
+    max_delta_sizes = shard_opts[:max_delta_sizes] || [100, 1000, 10_000]
 
     with :ok <- validate_down_period(down_period, broadcast_period),
          :ok <- validate_permdown_period(permdown_period, down_period),
          {:ok, tracker_state} <- tracker.init(tracker_opts) do
-
-      node_name        = Phoenix.PubSub.node_name(pubsub_server)
+      node_name = Phoenix.PubSub.node_name(pubsub_server)
       namespaced_topic = namespaced_topic(shard_name)
-      replica          = Replica.new(node_name)
+      replica = Replica.new(node_name)
 
       subscribe(pubsub_server, namespaced_topic)
       send_stuttered_heartbeat(self(), broadcast_period)
 
-      {:ok, %{shard_name: shard_name,
-              pubsub_server: pubsub_server,
-              tracker: tracker,
-              tracker_state: tracker_state,
-              replica: replica,
-              report_events_to: shard_opts[:report_events_to],
-              namespaced_topic: namespaced_topic,
-              log_level: log_level,
-              replicas: %{},
-              pending_clockset: [],
-              presences: State.new(Replica.ref(replica), shard_name),
-              broadcast_period: broadcast_period,
-              max_silent_periods: max_silent_periods,
-              silent_periods: max_silent_periods,
-              down_period: down_period,
-              permdown_period: permdown_period,
-              clock_sample_periods: clock_sample_periods,
-              deltas: [],
-              max_delta_sizes: max_delta_sizes,
-              current_sample_count: clock_sample_periods}}
+      {:ok,
+       %{
+         shard_name: shard_name,
+         pubsub_server: pubsub_server,
+         tracker: tracker,
+         tracker_state: tracker_state,
+         replica: replica,
+         report_events_to: shard_opts[:report_events_to],
+         namespaced_topic: namespaced_topic,
+         log_level: log_level,
+         replicas: %{},
+         pending_clockset: [],
+         presences: State.new(Replica.ref(replica), shard_name),
+         broadcast_period: broadcast_period,
+         max_silent_periods: max_silent_periods,
+         silent_periods: max_silent_periods,
+         down_period: down_period,
+         permdown_period: permdown_period,
+         clock_sample_periods: clock_sample_periods,
+         deltas: [],
+         max_delta_sizes: max_delta_sizes,
+         current_sample_count: clock_sample_periods
+       }}
     end
   end
 
-  def validate_down_period(d_period, b_period) when d_period < (2 * b_period) do
+  def validate_down_period(d_period, b_period) when d_period < 2 * b_period do
     {:error, "down_period must be at least twice as large as the broadcast_period"}
   end
+
   def validate_down_period(_d_period, _b_period), do: :ok
 
   def validate_permdown_period(p_period, d_period) when p_period <= d_period do
     {:error, "permdown_period must be at least larger than the down_period"}
   end
-  def validate_permdown_period(_p_period, _d_period), do: :ok
 
+  def validate_permdown_period(_p_period, _d_period), do: :ok
 
   defp send_stuttered_heartbeat(pid, interval) do
     Process.send_after(pid, :heartbeat, Enum.random(0..trunc(interval * 0.25)))
   end
 
   def handle_info(:heartbeat, state) do
-    {:noreply, state
-               |> broadcast_delta_heartbeat()
-               |> request_transfer_from_replicas_needing_synced()
-               |> detect_downs()
-               |> schedule_next_heartbeat()}
+    {:noreply,
+     state
+     |> broadcast_delta_heartbeat()
+     |> request_transfer_from_replicas_needing_synced()
+     |> detect_downs()
+     |> schedule_next_heartbeat()}
   end
 
   def handle_info({:pub, :heartbeat, {name, vsn}, :empty, clocks}, state) do
-    {:noreply, state
-               |> put_pending_clock(clocks)
-               |> handle_heartbeat({name, vsn})}
+    {:noreply,
+     state
+     |> put_pending_clock(clocks)
+     |> handle_heartbeat({name, vsn})}
   end
+
   def handle_info({:pub, :heartbeat, {name, vsn}, delta, clocks}, state) do
     state = handle_heartbeat(state, {name, vsn})
     {presences, joined, left} = State.merge(state.presences, delta)
 
-    {:noreply, state
-               |> report_diff(joined, left)
-               |> put_presences(presences)
-               |> put_pending_clock(clocks)
-               |> push_delta_generation(delta)}
+    {:noreply,
+     state
+     |> report_diff(joined, left)
+     |> put_presences(presences)
+     |> put_pending_clock(clocks)
+     |> push_delta_generation(delta)}
   end
 
   def handle_info({:pub, :transfer_req, ref, {name, _vsn}, {_, clocks}}, state) do
-    log state, fn -> "#{state.replica.name}: transfer_req from #{inspect name}" end
+    log(state, fn -> "#{state.replica.name}: transfer_req from #{inspect(name)}" end)
     delta = DeltaGeneration.extract(state.presences, state.deltas, name, clocks)
     msg = {:pub, :transfer_ack, ref, Replica.ref(state.replica), delta}
     direct_broadcast(state, name, msg)
@@ -198,19 +221,20 @@ defmodule Phoenix.Tracker.Shard do
   end
 
   def handle_info({:pub, :transfer_ack, _ref, {name, _vsn}, remote_presences}, state) do
-    log(state, fn -> "#{state.replica.name}: transfer_ack from #{inspect name}" end)
+    log(state, fn -> "#{state.replica.name}: transfer_ack from #{inspect(name)}" end)
     {presences, joined, left} = State.merge(state.presences, remote_presences)
 
-    {:noreply, state
-               |> report_diff(joined, left)
-               |> push_delta_generation(remote_presences)
-               |> put_presences(presences)}
+    {:noreply,
+     state
+     |> report_diff(joined, left)
+     |> push_delta_generation(remote_presences)
+     |> put_presences(presences)}
   end
 
   def handle_info({:pub, :graceful_permdown, {_name, _vsn} = ref}, state) do
     case Replica.fetch_by_ref(state.replicas, ref) do
       {:ok, replica} -> {:noreply, state |> down(replica) |> permdown(replica)}
-      :error         -> {:noreply, state}
+      :error -> {:noreply, state}
     end
   end
 
@@ -228,7 +252,7 @@ defmodule Phoenix.Tracker.Shard do
           raise ArgumentError, """
           expected #{state.tracker}.handle_info/2 to return {:noreply, state}, but got:
 
-              #{inspect other}
+              #{inspect(other)}
           """
       end
     else
@@ -245,6 +269,7 @@ defmodule Phoenix.Tracker.Shard do
       nil ->
         {state, ref} = put_presence(state, pid, topic, key, meta)
         {:reply, {:ok, ref}, state}
+
       _ ->
         {:reply, {:error, {:already_tracked, pid, topic, key}}, state}
     end
@@ -252,9 +277,11 @@ defmodule Phoenix.Tracker.Shard do
 
   def handle_call({:untrack, pid, topic, key}, _from, state) do
     new_state = drop_presence(state, pid, topic, key)
+
     if State.get_by_pid(new_state.presences, pid) == [] do
       Process.unlink(pid)
     end
+
     {:reply, :ok, new_state}
   end
 
@@ -263,7 +290,8 @@ defmodule Phoenix.Tracker.Shard do
     {:reply, :ok, drop_presence(state, pid)}
   end
 
-  def handle_call({:update, pid, topic, key, meta_updater}, _from, state) when is_function(meta_updater) do
+  def handle_call({:update, pid, topic, key, meta_updater}, _from, state)
+      when is_function(meta_updater) do
     handle_update({pid, topic, key, meta_updater}, state)
   end
 
@@ -303,10 +331,12 @@ defmodule Phoenix.Tracker.Shard do
     |> put_presences(State.leave(state.presences, pid, topic, key))
     |> put_presence(pid, topic, key, Map.put(meta, :phx_ref_prev, ref), prev_meta)
   end
+
   defp put_presence(state, pid, topic, key, meta, prev_meta \\ nil) do
     Process.link(pid)
     ref = random_ref()
     meta = Map.put(meta, :phx_ref, ref)
+
     new_state =
       state
       |> report_diff_join(topic, key, meta, prev_meta)
@@ -326,6 +356,7 @@ defmodule Phoenix.Tracker.Shard do
       state
     end
   end
+
   defp drop_presence(state, pid) do
     leaves = State.get_by_pid(state.presences, pid)
 
@@ -345,10 +376,14 @@ defmodule Phoenix.Tracker.Shard do
       {replicas, %Replica{vsn: ^vsn, status: :down}, %Replica{vsn: ^vsn, status: :up} = upped} ->
         up(%{state | replicas: replicas}, upped)
 
-      {replicas, %Replica{vsn: old, status: :up} = downed, %Replica{vsn: ^vsn, status: :up} = upped} when old != vsn ->
+      {replicas, %Replica{vsn: old, status: :up} = downed,
+       %Replica{vsn: ^vsn, status: :up} = upped}
+      when old != vsn ->
         %{state | replicas: replicas} |> down(downed) |> permdown(downed) |> up(upped)
 
-      {replicas, %Replica{vsn: old, status: :down} = downed, %Replica{vsn: ^vsn, status: :up} = upped} when old != vsn ->
+      {replicas, %Replica{vsn: old, status: :down} = downed,
+       %Replica{vsn: ^vsn, status: :up} = upped}
+      when old != vsn ->
         %{state | replicas: replicas} |> permdown(downed) |> up(upped)
     end
   end
@@ -359,12 +394,13 @@ defmodule Phoenix.Tracker.Shard do
 
     %{state | pending_clockset: [], current_sample_count: state.clock_sample_periods}
   end
+
   defp request_transfer_from_replicas_needing_synced(state) do
     %{state | current_sample_count: state.current_sample_count - 1}
   end
 
   defp request_transfer(state, {name, _vsn}) do
-    log state, fn -> "#{state.replica.name}: transfer_req from #{name}" end
+    log(state, fn -> "#{state.replica.name}: transfer_req from #{name}" end)
     ref = make_ref()
     msg = {:pub, :transfer_req, ref, Replica.ref(state.replica), clock(state)}
     direct_broadcast(state, name, msg)
@@ -395,7 +431,7 @@ defmodule Phoenix.Tracker.Shard do
 
   defp clock(state), do: State.clocks(state.presences)
 
-  @spec clockset_to_sync(t) :: [State.replica_name]
+  @spec clockset_to_sync(t) :: [State.replica_name()]
   defp clockset_to_sync(state) do
     my_ref = Replica.ref(state.replica)
 
@@ -411,7 +447,7 @@ defmodule Phoenix.Tracker.Shard do
 
   defp up(state, remote_replica) do
     report_event(state, {:replica_up, remote_replica.name})
-    log state, fn -> "#{state.replica.name}: replica up from #{inspect remote_replica.name}" end
+    log(state, fn -> "#{state.replica.name}: replica up from #{inspect(remote_replica.name)}" end)
     {presences, joined, []} = State.replica_up(state.presences, Replica.ref(remote_replica))
 
     state
@@ -421,7 +457,11 @@ defmodule Phoenix.Tracker.Shard do
 
   defp down(state, remote_replica) do
     report_event(state, {:replica_down, remote_replica.name})
-    log state, fn -> "#{state.replica.name}: replica down from #{inspect remote_replica.name}" end
+
+    log(state, fn ->
+      "#{state.replica.name}: replica down from #{inspect(remote_replica.name)}"
+    end)
+
     {presences, [], left} = State.replica_down(state.presences, Replica.ref(remote_replica))
 
     state
@@ -431,7 +471,7 @@ defmodule Phoenix.Tracker.Shard do
 
   defp permdown(state, %Replica{name: name} = remote_replica) do
     report_event(state, {:replica_permdown, name})
-    log state, fn -> "#{state.replica.name}: permanent replica down detected #{name}" end
+    log(state, fn -> "#{state.replica.name}: permanent replica down detected #{name}" end)
     replica_ref = Replica.ref(remote_replica)
     presences = State.remove_down_replicas(state.presences, replica_ref)
     deltas = DeltaGeneration.remove_down_replicas(state.deltas, replica_ref)
@@ -440,12 +480,14 @@ defmodule Phoenix.Tracker.Shard do
       {:ok, _replica} ->
         replicas = Map.delete(state.replicas, name)
         %{state | presences: presences, replicas: replicas, deltas: deltas}
+
       _ ->
         %{state | presences: presences, deltas: deltas}
     end
   end
 
   defp report_event(%{report_events_to: nil}, _event), do: :ok
+
   defp report_event(%{report_events_to: pid} = state, event) do
     send(pid, {event, state.replica.name})
   end
@@ -459,7 +501,12 @@ defmodule Phoenix.Tracker.Shard do
   end
 
   defp direct_broadcast(state, target_node, msg) do
-    Phoenix.PubSub.direct_broadcast!(target_node, state.pubsub_server, state.namespaced_topic, msg)
+    Phoenix.PubSub.direct_broadcast!(
+      target_node,
+      state.pubsub_server,
+      state.namespaced_topic,
+      msg
+    )
   end
 
   defp broadcast_delta_heartbeat(%{presences: presences} = state) do
@@ -468,30 +515,45 @@ defmodule Phoenix.Tracker.Shard do
         delta = presences.delta
         new_presences = presences |> State.reset_delta() |> State.compact()
 
-        broadcast_from(state, self(), {:pub, :heartbeat, Replica.ref(state.replica), delta, clock(state)})
+        broadcast_from(
+          state,
+          self(),
+          {:pub, :heartbeat, Replica.ref(state.replica), delta, clock(state)}
+        )
+
         %{state | presences: new_presences, silent_periods: 0}
         |> push_delta_generation(delta)
 
       state.silent_periods >= state.max_silent_periods ->
-        broadcast_from(state, self(), {:pub, :heartbeat, Replica.ref(state.replica), :empty, clock(state)})
+        broadcast_from(
+          state,
+          self(),
+          {:pub, :heartbeat, Replica.ref(state.replica), :empty, clock(state)}
+        )
+
         %{state | silent_periods: 0}
 
-      true -> update_in(state.silent_periods, &(&1 + 1))
+      true ->
+        update_in(state.silent_periods, &(&1 + 1))
     end
   end
 
   defp report_diff(state, [], []), do: state
+
   defp report_diff(state, joined, left) do
-    join_diff = Enum.reduce(joined, %{}, fn {{topic, _pid, key}, meta, _}, acc ->
-      Map.update(acc, topic, {[{key, meta}], []}, fn {joins, leaves} ->
-        {[{key, meta} | joins], leaves}
+    join_diff =
+      Enum.reduce(joined, %{}, fn {{topic, _pid, key}, meta, _}, acc ->
+        Map.update(acc, topic, {[{key, meta}], []}, fn {joins, leaves} ->
+          {[{key, meta} | joins], leaves}
+        end)
       end)
-    end)
-    full_diff = Enum.reduce(left, join_diff, fn {{topic, _pid, key}, meta, _}, acc ->
-      Map.update(acc, topic, {[], [{key, meta}]}, fn {joins, leaves} ->
-        {joins, [{key, meta} | leaves]}
+
+    full_diff =
+      Enum.reduce(left, join_diff, fn {{topic, _pid, key}, meta, _}, acc ->
+        Map.update(acc, topic, {[], [{key, meta}]}, fn {joins, leaves} ->
+          {joins, [{key, meta} | leaves]}
+        end)
       end)
-    end)
 
     full_diff
     |> state.tracker.handle_diff(state.tracker_state)
@@ -503,6 +565,7 @@ defmodule Phoenix.Tracker.Shard do
     |> state.tracker.handle_diff(state.tracker_state)
     |> handle_tracker_result(state)
   end
+
   defp report_diff_join(state, topic, key, meta, prev_meta) do
     %{topic => {[{key, meta}], [{key, prev_meta}]}}
     |> state.tracker.handle_diff(state.tracker_state)
@@ -512,11 +575,12 @@ defmodule Phoenix.Tracker.Shard do
   defp handle_tracker_result({:ok, tracker_state}, state) do
     %{state | tracker_state: tracker_state}
   end
+
   defp handle_tracker_result(other, state) do
     raise ArgumentError, """
     expected #{state.tracker}.handle_diff/2 to return {:ok, state}, but got:
 
-        #{inspect other}
+        #{inspect(other)}
     """
   end
 
@@ -524,6 +588,7 @@ defmodule Phoenix.Tracker.Shard do
     case State.get_by_pid(state.presences, pid, topic, key) do
       nil ->
         {:reply, {:error, :nopresence}, state}
+
       {{_topic, _pid, ^key}, prev_meta, {_replica, _}} ->
         {state, ref} = put_update(state, pid, topic, key, meta_updater.(prev_meta), prev_meta)
         {:reply, {:ok, ref}, state}
@@ -533,6 +598,7 @@ defmodule Phoenix.Tracker.Shard do
   defp push_delta_generation(state, {%State{mode: :normal}, _}) do
     %{state | deltas: []}
   end
+
   defp push_delta_generation(%{deltas: deltas} = state, %State{mode: :delta} = delta) do
     new_deltas = DeltaGeneration.push(state.presences, deltas, delta, state.max_delta_sizes)
     %{state | deltas: new_deltas}

--- a/lib/phoenix/tracker/shard.ex
+++ b/lib/phoenix/tracker/shard.ex
@@ -4,37 +4,36 @@ defmodule Phoenix.Tracker.Shard do
   alias Phoenix.Tracker.{Clock, State, Replica, DeltaGeneration}
   require Logger
 
-  @type presence :: {key :: String.t(), meta :: map()}
-  @type topic :: String.t()
+  @type presence :: {key :: String.t, meta :: map()}
+  @type topic :: String.t
 
-  @callback init(Keyword.t()) :: {:ok, pid} | {:error, reason :: term}
-  @callback handle_diff(%{topic => {joins :: [presence], leaves :: [presence]}}, state :: term) ::
-              {:ok, state :: term}
+  @callback init(Keyword.t) :: {:ok, pid} | {:error, reason :: term}
+  @callback handle_diff(%{topic => {joins :: [presence], leaves :: [presence]}}, state :: term) :: {:ok, state :: term}
   @callback handle_info(message :: term, state :: term) :: {:noreply, state :: term}
   @optional_callbacks handle_info: 2
 
   @type t :: %{
-          shard_name: String.t(),
-          pubsub_server: atom(),
-          tracker: module,
-          tracker_state: any,
-          replica: Replica.t(),
-          report_events_to: any,
-          namespaced_topic: String.t(),
-          log_level: boolean | atom,
-          replicas: map,
-          pending_clockset: [],
-          presences: State.t(),
-          broadcast_period: integer,
-          max_silent_periods: integer(),
-          silent_periods: integer(),
-          down_period: integer,
-          permdown_period: integer,
-          clock_sample_periods: integer,
-          deltas: [State.delta()],
-          max_delta_sizes: integer,
-          current_sample_count: integer
-        }
+    shard_name: String.t(),
+    pubsub_server: atom(),
+    tracker: module,
+    tracker_state: any,
+    replica: Replica.t(),
+    report_events_to: any,
+    namespaced_topic: String.t(),
+    log_level: boolean | atom,
+    replicas: map,
+    pending_clockset: [],
+    presences: State.t(),
+    broadcast_period: integer,
+    max_silent_periods: integer(),
+    silent_periods: integer(),
+    down_period: integer,
+    permdown_period: integer,
+    clock_sample_periods: integer,
+    deltas: [State.delta()],
+    max_delta_sizes: integer,
+    current_sample_count: integer
+  }
 
   ## Used by Phoenix.Tracker for dispatching to appropriate shard
   @spec name_for_number(atom, non_neg_integer) :: atom
@@ -59,15 +58,12 @@ defmodule Phoenix.Tracker.Shard do
   def untrack(server_pid, pid, topic, key) when is_pid(pid) do
     GenServer.call(server_pid, {:untrack, pid, topic, key})
   end
-
   def untrack(server_pid, pid) when is_pid(pid) do
     GenServer.call(server_pid, {:untrack, pid})
   end
 
-  @spec update(pid, pid, topic, term, map() | (map() -> map())) ::
-          {:ok, ref :: binary} | {:error, reason :: term}
-  def update(server_pid, pid, topic, key, meta)
-      when is_pid(pid) and (is_map(meta) or is_function(meta)) do
+  @spec update(pid, pid, topic, term, map() | (map() -> map())) :: {:ok, ref :: binary} | {:error, reason :: term}
+  def update(server_pid, pid, topic, key, meta) when is_pid(pid) and (is_map(meta) or is_function(meta)) do
     GenServer.call(server_pid, {:update, pid, topic, key, meta})
   end
 
@@ -107,112 +103,98 @@ defmodule Phoenix.Tracker.Shard do
     tracker_name = Keyword.fetch!(pool_opts, :name)
     name = name_for_number(tracker_name, number)
     shard_opts = Keyword.put(pool_opts, :name, name)
-
-    GenServer.start_link(
-      __MODULE__,
-      [tracker, tracker_opts, shard_opts],
-      name: name
-    )
+    GenServer.start_link(__MODULE__,
+      [tracker, tracker_opts, shard_opts], name: name)
   end
 
   def init([tracker, tracker_opts, shard_opts]) do
     Process.flag(:trap_exit, true)
-    shard_name = Keyword.fetch!(shard_opts, :name)
-    pubsub_server = Keyword.fetch!(shard_opts, :pubsub_server)
-    broadcast_period = shard_opts[:broadcast_period] || 1500
-    max_silent_periods = shard_opts[:max_silent_periods] || 10
-
-    down_period =
-      shard_opts[:down_period] ||
-        broadcast_period * max_silent_periods * 2
-
-    permdown_period = shard_opts[:permdown_period] || 1_200_000
+    shard_name           = Keyword.fetch!(shard_opts, :name)
+    pubsub_server        = Keyword.fetch!(shard_opts, :pubsub_server)
+    broadcast_period     = shard_opts[:broadcast_period] || 1500
+    max_silent_periods   = shard_opts[:max_silent_periods] || 10
+    down_period          = shard_opts[:down_period]
+                         || (broadcast_period * max_silent_periods * 2)
+    permdown_period      = shard_opts[:permdown_period] || 1_200_000
     clock_sample_periods = shard_opts[:clock_sample_periods] || 2
-    log_level = Keyword.get(shard_opts, :log_level, false)
-    max_delta_sizes = shard_opts[:max_delta_sizes] || [100, 1000, 10_000]
+    log_level            = Keyword.get(shard_opts, :log_level, false)
+    max_delta_sizes      = shard_opts[:max_delta_sizes] || [100, 1000, 10_000]
 
     with :ok <- validate_down_period(down_period, broadcast_period),
          :ok <- validate_permdown_period(permdown_period, down_period),
          {:ok, tracker_state} <- tracker.init(tracker_opts) do
-      node_name = Phoenix.PubSub.node_name(pubsub_server)
+
+      node_name        = Phoenix.PubSub.node_name(pubsub_server)
       namespaced_topic = namespaced_topic(shard_name)
-      replica = Replica.new(node_name)
+      replica          = Replica.new(node_name)
 
       subscribe(pubsub_server, namespaced_topic)
       send_stuttered_heartbeat(self(), broadcast_period)
 
-      {:ok,
-       %{
-         shard_name: shard_name,
-         pubsub_server: pubsub_server,
-         tracker: tracker,
-         tracker_state: tracker_state,
-         replica: replica,
-         report_events_to: shard_opts[:report_events_to],
-         namespaced_topic: namespaced_topic,
-         log_level: log_level,
-         replicas: %{},
-         pending_clockset: [],
-         presences: State.new(Replica.ref(replica), shard_name),
-         broadcast_period: broadcast_period,
-         max_silent_periods: max_silent_periods,
-         silent_periods: max_silent_periods,
-         down_period: down_period,
-         permdown_period: permdown_period,
-         clock_sample_periods: clock_sample_periods,
-         deltas: [],
-         max_delta_sizes: max_delta_sizes,
-         current_sample_count: clock_sample_periods
-       }}
+      {:ok, %{shard_name: shard_name,
+              pubsub_server: pubsub_server,
+              tracker: tracker,
+              tracker_state: tracker_state,
+              replica: replica,
+              report_events_to: shard_opts[:report_events_to],
+              namespaced_topic: namespaced_topic,
+              log_level: log_level,
+              replicas: %{},
+              pending_clockset: [],
+              presences: State.new(Replica.ref(replica), shard_name),
+              broadcast_period: broadcast_period,
+              max_silent_periods: max_silent_periods,
+              silent_periods: max_silent_periods,
+              down_period: down_period,
+              permdown_period: permdown_period,
+              clock_sample_periods: clock_sample_periods,
+              deltas: [],
+              max_delta_sizes: max_delta_sizes,
+              current_sample_count: clock_sample_periods}}
     end
   end
 
-  def validate_down_period(d_period, b_period) when d_period < 2 * b_period do
+  def validate_down_period(d_period, b_period) when d_period < (2 * b_period) do
     {:error, "down_period must be at least twice as large as the broadcast_period"}
   end
-
   def validate_down_period(_d_period, _b_period), do: :ok
 
   def validate_permdown_period(p_period, d_period) when p_period <= d_period do
     {:error, "permdown_period must be at least larger than the down_period"}
   end
-
   def validate_permdown_period(_p_period, _d_period), do: :ok
+
 
   defp send_stuttered_heartbeat(pid, interval) do
     Process.send_after(pid, :heartbeat, Enum.random(0..trunc(interval * 0.25)))
   end
 
   def handle_info(:heartbeat, state) do
-    {:noreply,
-     state
-     |> broadcast_delta_heartbeat()
-     |> request_transfer_from_replicas_needing_synced()
-     |> detect_downs()
-     |> schedule_next_heartbeat()}
+    {:noreply, state
+               |> broadcast_delta_heartbeat()
+               |> request_transfer_from_replicas_needing_synced()
+               |> detect_downs()
+               |> schedule_next_heartbeat()}
   end
 
   def handle_info({:pub, :heartbeat, {name, vsn}, :empty, clocks}, state) do
-    {:noreply,
-     state
-     |> put_pending_clock(clocks)
-     |> handle_heartbeat({name, vsn})}
+    {:noreply, state
+               |> put_pending_clock(clocks)
+               |> handle_heartbeat({name, vsn})}
   end
-
   def handle_info({:pub, :heartbeat, {name, vsn}, delta, clocks}, state) do
     state = handle_heartbeat(state, {name, vsn})
     {presences, joined, left} = State.merge(state.presences, delta)
 
-    {:noreply,
-     state
-     |> report_diff(joined, left)
-     |> put_presences(presences)
-     |> put_pending_clock(clocks)
-     |> push_delta_generation(delta)}
+    {:noreply, state
+               |> report_diff(joined, left)
+               |> put_presences(presences)
+               |> put_pending_clock(clocks)
+               |> push_delta_generation(delta)}
   end
 
   def handle_info({:pub, :transfer_req, ref, {name, _vsn}, {_, clocks}}, state) do
-    log(state, fn -> "#{state.replica.name}: transfer_req from #{inspect(name)}" end)
+    log state, fn -> "#{state.replica.name}: transfer_req from #{inspect name}" end
     delta = DeltaGeneration.extract(state.presences, state.deltas, name, clocks)
     msg = {:pub, :transfer_ack, ref, Replica.ref(state.replica), delta}
     direct_broadcast(state, name, msg)
@@ -221,20 +203,19 @@ defmodule Phoenix.Tracker.Shard do
   end
 
   def handle_info({:pub, :transfer_ack, _ref, {name, _vsn}, remote_presences}, state) do
-    log(state, fn -> "#{state.replica.name}: transfer_ack from #{inspect(name)}" end)
+    log(state, fn -> "#{state.replica.name}: transfer_ack from #{inspect name}" end)
     {presences, joined, left} = State.merge(state.presences, remote_presences)
 
-    {:noreply,
-     state
-     |> report_diff(joined, left)
-     |> push_delta_generation(remote_presences)
-     |> put_presences(presences)}
+    {:noreply, state
+               |> report_diff(joined, left)
+               |> push_delta_generation(remote_presences)
+               |> put_presences(presences)}
   end
 
   def handle_info({:pub, :graceful_permdown, {_name, _vsn} = ref}, state) do
     case Replica.fetch_by_ref(state.replicas, ref) do
       {:ok, replica} -> {:noreply, state |> down(replica) |> permdown(replica)}
-      :error -> {:noreply, state}
+      :error         -> {:noreply, state}
     end
   end
 
@@ -252,7 +233,7 @@ defmodule Phoenix.Tracker.Shard do
           raise ArgumentError, """
           expected #{state.tracker}.handle_info/2 to return {:noreply, state}, but got:
 
-              #{inspect(other)}
+              #{inspect other}
           """
       end
     else
@@ -269,7 +250,6 @@ defmodule Phoenix.Tracker.Shard do
       nil ->
         {state, ref} = put_presence(state, pid, topic, key, meta)
         {:reply, {:ok, ref}, state}
-
       _ ->
         {:reply, {:error, {:already_tracked, pid, topic, key}}, state}
     end
@@ -277,11 +257,9 @@ defmodule Phoenix.Tracker.Shard do
 
   def handle_call({:untrack, pid, topic, key}, _from, state) do
     new_state = drop_presence(state, pid, topic, key)
-
     if State.get_by_pid(new_state.presences, pid) == [] do
       Process.unlink(pid)
     end
-
     {:reply, :ok, new_state}
   end
 
@@ -290,8 +268,7 @@ defmodule Phoenix.Tracker.Shard do
     {:reply, :ok, drop_presence(state, pid)}
   end
 
-  def handle_call({:update, pid, topic, key, meta_updater}, _from, state)
-      when is_function(meta_updater) do
+  def handle_call({:update, pid, topic, key, meta_updater}, _from, state) when is_function(meta_updater) do
     handle_update({pid, topic, key, meta_updater}, state)
   end
 
@@ -331,12 +308,10 @@ defmodule Phoenix.Tracker.Shard do
     |> put_presences(State.leave(state.presences, pid, topic, key))
     |> put_presence(pid, topic, key, Map.put(meta, :phx_ref_prev, ref), prev_meta)
   end
-
   defp put_presence(state, pid, topic, key, meta, prev_meta \\ nil) do
     Process.link(pid)
     ref = random_ref()
     meta = Map.put(meta, :phx_ref, ref)
-
     new_state =
       state
       |> report_diff_join(topic, key, meta, prev_meta)
@@ -356,7 +331,6 @@ defmodule Phoenix.Tracker.Shard do
       state
     end
   end
-
   defp drop_presence(state, pid) do
     leaves = State.get_by_pid(state.presences, pid)
 
@@ -376,14 +350,10 @@ defmodule Phoenix.Tracker.Shard do
       {replicas, %Replica{vsn: ^vsn, status: :down}, %Replica{vsn: ^vsn, status: :up} = upped} ->
         up(%{state | replicas: replicas}, upped)
 
-      {replicas, %Replica{vsn: old, status: :up} = downed,
-       %Replica{vsn: ^vsn, status: :up} = upped}
-      when old != vsn ->
+      {replicas, %Replica{vsn: old, status: :up} = downed, %Replica{vsn: ^vsn, status: :up} = upped} when old != vsn ->
         %{state | replicas: replicas} |> down(downed) |> permdown(downed) |> up(upped)
 
-      {replicas, %Replica{vsn: old, status: :down} = downed,
-       %Replica{vsn: ^vsn, status: :up} = upped}
-      when old != vsn ->
+      {replicas, %Replica{vsn: old, status: :down} = downed, %Replica{vsn: ^vsn, status: :up} = upped} when old != vsn ->
         %{state | replicas: replicas} |> permdown(downed) |> up(upped)
     end
   end
@@ -394,13 +364,12 @@ defmodule Phoenix.Tracker.Shard do
 
     %{state | pending_clockset: [], current_sample_count: state.clock_sample_periods}
   end
-
   defp request_transfer_from_replicas_needing_synced(state) do
     %{state | current_sample_count: state.current_sample_count - 1}
   end
 
   defp request_transfer(state, {name, _vsn}) do
-    log(state, fn -> "#{state.replica.name}: transfer_req from #{name}" end)
+    log state, fn -> "#{state.replica.name}: transfer_req from #{name}" end
     ref = make_ref()
     msg = {:pub, :transfer_req, ref, Replica.ref(state.replica), clock(state)}
     direct_broadcast(state, name, msg)
@@ -431,7 +400,7 @@ defmodule Phoenix.Tracker.Shard do
 
   defp clock(state), do: State.clocks(state.presences)
 
-  @spec clockset_to_sync(t) :: [State.replica_name()]
+  @spec clockset_to_sync(t) :: [State.replica_name]
   defp clockset_to_sync(state) do
     my_ref = Replica.ref(state.replica)
 
@@ -447,7 +416,7 @@ defmodule Phoenix.Tracker.Shard do
 
   defp up(state, remote_replica) do
     report_event(state, {:replica_up, remote_replica.name})
-    log(state, fn -> "#{state.replica.name}: replica up from #{inspect(remote_replica.name)}" end)
+    log state, fn -> "#{state.replica.name}: replica up from #{inspect remote_replica.name}" end
     {presences, joined, []} = State.replica_up(state.presences, Replica.ref(remote_replica))
 
     state
@@ -457,11 +426,7 @@ defmodule Phoenix.Tracker.Shard do
 
   defp down(state, remote_replica) do
     report_event(state, {:replica_down, remote_replica.name})
-
-    log(state, fn ->
-      "#{state.replica.name}: replica down from #{inspect(remote_replica.name)}"
-    end)
-
+    log state, fn -> "#{state.replica.name}: replica down from #{inspect remote_replica.name}" end
     {presences, [], left} = State.replica_down(state.presences, Replica.ref(remote_replica))
 
     state
@@ -471,7 +436,7 @@ defmodule Phoenix.Tracker.Shard do
 
   defp permdown(state, %Replica{name: name} = remote_replica) do
     report_event(state, {:replica_permdown, name})
-    log(state, fn -> "#{state.replica.name}: permanent replica down detected #{name}" end)
+    log state, fn -> "#{state.replica.name}: permanent replica down detected #{name}" end
     replica_ref = Replica.ref(remote_replica)
     presences = State.remove_down_replicas(state.presences, replica_ref)
     deltas = DeltaGeneration.remove_down_replicas(state.deltas, replica_ref)
@@ -480,14 +445,12 @@ defmodule Phoenix.Tracker.Shard do
       {:ok, _replica} ->
         replicas = Map.delete(state.replicas, name)
         %{state | presences: presences, replicas: replicas, deltas: deltas}
-
       _ ->
         %{state | presences: presences, deltas: deltas}
     end
   end
 
   defp report_event(%{report_events_to: nil}, _event), do: :ok
-
   defp report_event(%{report_events_to: pid} = state, event) do
     send(pid, {event, state.replica.name})
   end
@@ -501,12 +464,7 @@ defmodule Phoenix.Tracker.Shard do
   end
 
   defp direct_broadcast(state, target_node, msg) do
-    Phoenix.PubSub.direct_broadcast!(
-      target_node,
-      state.pubsub_server,
-      state.namespaced_topic,
-      msg
-    )
+    Phoenix.PubSub.direct_broadcast!(target_node, state.pubsub_server, state.namespaced_topic, msg)
   end
 
   defp broadcast_delta_heartbeat(%{presences: presences} = state) do
@@ -515,45 +473,30 @@ defmodule Phoenix.Tracker.Shard do
         delta = presences.delta
         new_presences = presences |> State.reset_delta() |> State.compact()
 
-        broadcast_from(
-          state,
-          self(),
-          {:pub, :heartbeat, Replica.ref(state.replica), delta, clock(state)}
-        )
-
+        broadcast_from(state, self(), {:pub, :heartbeat, Replica.ref(state.replica), delta, clock(state)})
         %{state | presences: new_presences, silent_periods: 0}
         |> push_delta_generation(delta)
 
       state.silent_periods >= state.max_silent_periods ->
-        broadcast_from(
-          state,
-          self(),
-          {:pub, :heartbeat, Replica.ref(state.replica), :empty, clock(state)}
-        )
-
+        broadcast_from(state, self(), {:pub, :heartbeat, Replica.ref(state.replica), :empty, clock(state)})
         %{state | silent_periods: 0}
 
-      true ->
-        update_in(state.silent_periods, &(&1 + 1))
+      true -> update_in(state.silent_periods, &(&1 + 1))
     end
   end
 
   defp report_diff(state, [], []), do: state
-
   defp report_diff(state, joined, left) do
-    join_diff =
-      Enum.reduce(joined, %{}, fn {{topic, _pid, key}, meta, _}, acc ->
-        Map.update(acc, topic, {[{key, meta}], []}, fn {joins, leaves} ->
-          {[{key, meta} | joins], leaves}
-        end)
+    join_diff = Enum.reduce(joined, %{}, fn {{topic, _pid, key}, meta, _}, acc ->
+      Map.update(acc, topic, {[{key, meta}], []}, fn {joins, leaves} ->
+        {[{key, meta} | joins], leaves}
       end)
-
-    full_diff =
-      Enum.reduce(left, join_diff, fn {{topic, _pid, key}, meta, _}, acc ->
-        Map.update(acc, topic, {[], [{key, meta}]}, fn {joins, leaves} ->
-          {joins, [{key, meta} | leaves]}
-        end)
+    end)
+    full_diff = Enum.reduce(left, join_diff, fn {{topic, _pid, key}, meta, _}, acc ->
+      Map.update(acc, topic, {[], [{key, meta}]}, fn {joins, leaves} ->
+        {joins, [{key, meta} | leaves]}
       end)
+    end)
 
     full_diff
     |> state.tracker.handle_diff(state.tracker_state)
@@ -565,7 +508,6 @@ defmodule Phoenix.Tracker.Shard do
     |> state.tracker.handle_diff(state.tracker_state)
     |> handle_tracker_result(state)
   end
-
   defp report_diff_join(state, topic, key, meta, prev_meta) do
     %{topic => {[{key, meta}], [{key, prev_meta}]}}
     |> state.tracker.handle_diff(state.tracker_state)
@@ -575,12 +517,11 @@ defmodule Phoenix.Tracker.Shard do
   defp handle_tracker_result({:ok, tracker_state}, state) do
     %{state | tracker_state: tracker_state}
   end
-
   defp handle_tracker_result(other, state) do
     raise ArgumentError, """
     expected #{state.tracker}.handle_diff/2 to return {:ok, state}, but got:
 
-        #{inspect(other)}
+        #{inspect other}
     """
   end
 
@@ -588,7 +529,6 @@ defmodule Phoenix.Tracker.Shard do
     case State.get_by_pid(state.presences, pid, topic, key) do
       nil ->
         {:reply, {:error, :nopresence}, state}
-
       {{_topic, _pid, ^key}, prev_meta, {_replica, _}} ->
         {state, ref} = put_update(state, pid, topic, key, meta_updater.(prev_meta), prev_meta)
         {:reply, {:ok, ref}, state}
@@ -598,7 +538,6 @@ defmodule Phoenix.Tracker.Shard do
   defp push_delta_generation(state, {%State{mode: :normal}, _}) do
     %{state | deltas: []}
   end
-
   defp push_delta_generation(%{deltas: deltas} = state, %State{mode: :delta} = delta) do
     new_deltas = DeltaGeneration.push(state.presences, deltas, delta, state.max_delta_sizes)
     %{state | deltas: new_deltas}

--- a/test/phoenix/tracker/shard_replication_test.exs
+++ b/test/phoenix/tracker/shard_replication_test.exs
@@ -244,6 +244,8 @@ defmodule Phoenix.Tracker.ShardReplicationTest do
     assert %{@node1 => %Replica{status: :up}} = replicas(shard)
     assert [{"local1", _}, {"node1", _}] = list(shard, topic)
     assert [{"local1", _}, {"node1", _}] = dirty_list(shard, topic)
+    assert [_] = Shard.dirty_get_by_key(shard, topic, "local1")
+    assert [_] = Shard.dirty_get_by_key(shard, topic, "node1")
 
     # nodedown
     Process.unlink(node_pid)
@@ -252,9 +254,13 @@ defmodule Phoenix.Tracker.ShardReplicationTest do
     assert %{@node1 => %Replica{status: :down}} = replicas(shard)
     assert [{"local1", _}] = list(shard, topic)
     assert [{"local1", _}, {"node1", _}] = dirty_list(shard, topic)
+    assert [_] = Shard.dirty_get_by_key(shard, topic, "local1")
+    assert [_] = Shard.dirty_get_by_key(shard, topic, "node1")
 
     :timer.sleep(@permdown + 2*@heartbeat)
     assert [{"local1", _}] = dirty_list(shard, topic)
+    assert [_] = Shard.dirty_get_by_key(shard, topic, "local1")
+    assert [] = Shard.dirty_get_by_key(shard, topic, "node1")
   end
 
 


### PR DESCRIPTION
This pull request includes a dirty version of the `get_by_key` function. It also modifies `Tracker.list` to use the standard presence list mechanism, and it introduces `dirty_list` as a standalone function.