### PR TITLE
Add Tracker.size/1 api

### DIFF
--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -269,6 +269,17 @@ defmodule Phoenix.Tracker do
     Supervisor.stop(tracker_name)
   end
 
+  @doc false
+  @spec size(atom) :: non_neg_integer
+  def size(tracker_name) do
+    0..(pool_size(tracker_name) - 1)
+    |> Enum.reduce(0, fn n, acc ->
+      shard_name = Shard.name_for_number(tracker_name, n)
+
+      Phoenix.Tracker.Shard.size(shard_name) + acc
+    end)
+  end
+
   @doc """
   Starts a tracker pool.
 

--- a/lib/phoenix/tracker/shard.ex
+++ b/lib/phoenix/tracker/shard.ex
@@ -101,6 +101,11 @@ defmodule Phoenix.Tracker.Shard do
     GenServer.call(server_pid, :graceful_permdown)
   end
 
+  @spec size(atom) :: non_neg_integer
+  def size(shard_name) do
+    State.size(shard_name)
+  end
+
   ## Server
 
   def start_link(tracker, tracker_opts, pool_opts) do

--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -62,6 +62,11 @@ defmodule Phoenix.Tracker.State do
       replicas: %{replica => :up}})
   end
 
+  @spec size(atom) :: non_neg_integer
+  def size(table) do
+    :ets.info(table, :size)
+  end
+
   @doc """
   Returns the causal context for the set.
   """

--- a/test/phoenix/tracker/pool_test.exs
+++ b/test/phoenix/tracker/pool_test.exs
@@ -168,5 +168,16 @@ defmodule Phoenix.Tracker.PoolTest do
 
       for t <- topics, do: assert Tracker.list(server, t) == []
     end
+
+    @tag pool_size: pool_size
+    test "pool #{pool_size}: count/1 returns number of entries across all shards",
+    %{server: server} do
+      topics = for i <- 1..100, do: "topic_#{i}"
+      for t <- topics do
+        {:ok, _ref} = Tracker.track(server, self(), t, "me", %{a: "b"})
+      end
+
+      assert Tracker.size(server) == 100
+    end
   end
 end

--- a/test/phoenix/tracker/shard_test.exs
+++ b/test/phoenix/tracker/shard_test.exs
@@ -13,4 +13,45 @@ defmodule Phoenix.Tracker.ShardTest do
     assert Phoenix.Tracker.Shard.init([nil, nil, opts]) ==
       {:error, "permdown_period must be at least larger than the down_period"}
   end
+
+  defmodule TestTracker do
+    use Phoenix.Tracker
+    def init(state), do: {:ok, state}
+    def handle_diff(_diff, state), do: {:ok, state}
+  end
+
+  describe "size/1" do
+    test "returns 0 when there are no entries in the shard" do
+      tracker = TestTracker
+      name = :"#{inspect(make_ref())}"
+      shard_name = Phoenix.Tracker.Shard.name_for_number(name, 1)
+      given_pubsub(name)
+      opts = [pubsub_server: name, name: name, shard_number: 1]
+      {:ok, _pid} = Phoenix.Tracker.Shard.start_link(tracker, %{}, opts)
+
+      assert Phoenix.Tracker.Shard.size(shard_name) == 0
+    end
+
+    test "returns number of tracked entries in the shard" do
+      tracker = TestTracker
+      name = :"#{inspect(make_ref())}"
+      shard_name = Phoenix.Tracker.Shard.name_for_number(name, 1)
+      given_pubsub(name)
+      opts = [pubsub_server: name, name: name, shard_number: 1]
+      {:ok, pid} = Phoenix.Tracker.Shard.start_link(tracker, %{}, opts)
+
+      for i <- 1..100 do
+        Phoenix.Tracker.Shard.track(pid, self(), "topic", "user#{i}", %{})
+      end
+
+      assert Phoenix.Tracker.Shard.size(shard_name) == 100
+    end
+
+    defp given_pubsub(name) do
+      size = 1
+      {adapter, adapter_opts} = Application.get_env(:phoenix_pubsub, :test_adapter)
+      adapter_opts = [adapter: adapter, name: name, pool_size: size] ++ adapter_opts
+      start_supervised!({Phoenix.PubSub, adapter_opts})
+    end
+  end
 end


### PR DESCRIPTION
We need to keep track of the number of tracker entries available locally, so that we can monitor the pace of synchronization with other nodes after startup. We can consider the node to be ready only when the synchronization process slows down after initial fast-paced state synchronization.