### PR TITLE
Observe removes optimization

### DIFF
--- a/test/phoenix/tracker/delta_generation_test.exs
+++ b/test/phoenix/tracker/delta_generation_test.exs
@@ -115,7 +115,7 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
     s1 = new(:r1, config)
     s2 = State.join(s1, pid, "lobby", "user1", %{})
 
-    expected_state = %{s2 | pids: nil, values: nil, delta: :unset}
+    expected_state = %{s2 | pids: nil, tags: nil, values: nil, delta: :unset}
     expected_values = %{{:r1, 1} => {pid, "lobby", "user1", %{}}}
 
     assert DeltaGeneration.extract(s2, [], :r2, %{r1: 1}) ==


### PR DESCRIPTION
Replicating the observe_removes optimization from here: https://github.com/salemove/phoenix_pubsub/pull/1

The main benefit of this optimization is avoiding a heavy ETS scan operation in CRDT merge operation by having a tags lookup table that maps tag -> values_key (right now, we only have the mapping of values_key -> tag mapping from values ets table in the Phoenix.Tracker.State module). Having this reverse lookup eliminates the expensive scan, and is yielding heavy performance benefits (in terms of lowering CPU usage and lower P95 latencies for Phoenix.Tracker.track).


We have tested that this change is safe by deploying live-service w/ this version of Phoenix Tracker while it was running old version of tracker. Hence, this is safe to merge and release with live-service.